### PR TITLE
DSL-107- Add mapping for dplrid parameter sent in doppler campaign

### DIFF
--- a/Doppler.Integrations/Controllers/TypeformController.cs
+++ b/Doppler.Integrations/Controllers/TypeformController.cs
@@ -60,7 +60,11 @@ namespace Doppler.Integrations.Controllers
             catch (Exception ex)
             {
                 _log.LogError(new EventId(), ex, string.Format("AccountName: {0} | ID_List: {1} | Status: Add subscriber has failed", accountName, idList));
-                return new BadRequestResult();
+                return BadRequest(new
+                {
+                    ErrorMessage = "An subscriber email must be provided",
+                    HelpLink = HELP_LINK
+                });
             }
         }
     }

--- a/Doppler.Integrations/Controllers/TypeformController.cs
+++ b/Doppler.Integrations/Controllers/TypeformController.cs
@@ -62,7 +62,8 @@ namespace Doppler.Integrations.Controllers
                 _log.LogError(new EventId(), ex, string.Format("AccountName: {0} | ID_List: {1} | Status: Add subscriber has failed", accountName, idList));
                 return BadRequest(new
                 {
-                    ErrorMessage = "An subscriber email must be provided",
+                    ErrorMessage = ex.Message,
+                    StackTrace = ex.StackTrace,
                     HelpLink = HELP_LINK
                 });
             }

--- a/Doppler.Integrations/Mapper/MapperSubscriber.cs
+++ b/Doppler.Integrations/Mapper/MapperSubscriber.cs
@@ -6,6 +6,7 @@ using Doppler.Integrations.Models.Dtos;
 using System.Text.RegularExpressions;
 using System;
 using Doppler.Integrations.Models.Dtos.Typeform;
+using System.Text;
 
 namespace Doppler.Integrations.Mapper
 {
@@ -144,21 +145,27 @@ namespace Doppler.Integrations.Mapper
 
         public DopplerSubscriberDto TypeFormToSubscriberDTO(TypeformDTO rawSubscriber, ItemsDto allowedFields)
         {
-            DopplerSubscriberDto dopplerSubscriber = new DopplerSubscriberDto
+            DopplerSubscriberDto dopplerSubscriber = new DopplerSubscriberDto();
+            try
             {
-                Email = rawSubscriber
-                    .form_response
-                    .answers
-                    .FirstOrDefault(x => !String.IsNullOrEmpty(x.email))
-                    .email
-            };
-
-            if (String.IsNullOrEmpty(dopplerSubscriber.Email))
-            {
-                _log.LogWarning(String.Format("The response event: {0} to the form: {1} with ID: {2} has not included an email", rawSubscriber.event_id, rawSubscriber.form_response.definition.title, rawSubscriber.form_response.definition.id));
-                throw new ArgumentNullException(nameof(dopplerSubscriber.Email));
+                dopplerSubscriber.Email = rawSubscriber
+                       .form_response
+                       .answers
+                       .FirstOrDefault(x => !String.IsNullOrEmpty(x.email))
+                       .email;
             }
-
+            catch (Exception ex)
+            {
+                dopplerSubscriber.Email = DecodeDPLRID(rawSubscriber.form_response.hidden.dplrid);
+            }
+            finally
+            {
+                if (String.IsNullOrEmpty(dopplerSubscriber.Email))
+                {
+                    _log.LogWarning(String.Format("The response event: {0} to the form: {1} with ID: {2} has not included an email", rawSubscriber.event_id, rawSubscriber.form_response.definition.title, rawSubscriber.form_response.definition.id));
+                    throw new ArgumentNullException(nameof(dopplerSubscriber.Email));
+                }
+            }
             var answersById = rawSubscriber.form_response.answers
                     .Where(x=> String.IsNullOrEmpty(x.email) )
                     .ToDictionary(y => y.field.id);
@@ -228,6 +235,22 @@ namespace Doppler.Integrations.Mapper
                 answerValue = null;
 
             return answerValue;
+        }
+
+        private string DecodeDPLRID(string dplrid)
+        {
+            var rtfBytes = FromHex(dplrid);
+            return Encoding.ASCII.GetString(rtfBytes);
+        }
+
+        public static byte[] FromHex(string hex)
+        {
+            var result = new byte[hex.Length / 2];
+            for (var i = 0; i < result.Length; i++)
+            {
+                result[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+            }
+            return result;
         }
     }
 }

--- a/Doppler.Integrations/Models/Dtos/Typeform/FormResponse.cs
+++ b/Doppler.Integrations/Models/Dtos/Typeform/FormResponse.cs
@@ -9,5 +9,6 @@ namespace Doppler.Integrations.Models.Dtos.Typeform
     {
         public Definition definition { get; set; }
         public List<Answer> answers { get; set; }
+        public Hidden hidden { get; set; }
     }
 }

--- a/Doppler.Integrations/Models/Dtos/Typeform/Hidden.cs
+++ b/Doppler.Integrations/Models/Dtos/Typeform/Hidden.cs
@@ -1,0 +1,7 @@
+﻿namespace Doppler.Integrations.Models.Dtos.Typeform
+{
+    public class Hidden
+    {
+        public string dplrid { get; set; }
+    }
+}


### PR DESCRIPTION
Add dplrid field , through the Hidden class in FormResponse mapping, then in the body of the request that Typeform sends us, we take the email from the JSON .
So when we send doppler campaigns to typeform it can be used in the subscriber's email field 

Jira Ticket: https://makingsense.atlassian.net/browse/DSL-107